### PR TITLE
feature: Feature/upgrade mcp sdk

### DIFF
--- a/scala/turnstile/project/Dependencies.scala
+++ b/scala/turnstile/project/Dependencies.scala
@@ -19,12 +19,13 @@
 import sbt.*
 
 object Dependencies {
-  val pekkoVersion = "1.3.0"
+  val pekkoVersion = "1.6.0"
   val pekkoHttpVersion = "1.2.0"
   val pekkoGrpcVersion = "1.1.1"
   val akkaManagementVersion = "1.1.1"
   val json4sJacksonVersion = "4.0.7"
   val circeVersion = "0.14.6"
+  val circeJackson29Version = "0.14.2"
   val logbackVersion = "1.5.15"
   val scalaLoggingVersion = "3.9.5"
   val scalaMockVersion = "6.1.1"
@@ -35,13 +36,16 @@ object Dependencies {
   val jwtScalaVersion = "10.0.1"
   val auth0JwksRsaVersion = "0.22.1"
   val protobufJavaUtilVersion = "3.25.6"
-  val mcpSdkVersion = "0.16.0"
+  val mcpSdkVersion = "1.1.3"
+  val springAiVersion = "1.1.7"
   val slickVersion = "3.5.2"
   val slickPgVersion = "0.22.2"
   val postgresqlVersion = "42.7.4"
   val hikariCPVersion = "6.2.1"
   val flywayVersion = "11.1.0"
   val springVersion = "6.2.1"
+  val openAiVersion = "4.12.0"
+  val googleCloudStorageVersion = "2.58.1"
 
   val dependencies = Seq(
     "org.apache.pekko" %% "pekko-actor" % pekkoVersion,
@@ -87,7 +91,7 @@ object Dependencies {
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-jackson29" % "0.14.2",
+    "io.circe" %% "circe-jackson29" % circeJackson29Version,
 
     // (using io.circe.generic.auto._ instead of circe-generic-extras)
     "ch.qos.logback" % "logback-classic" % logbackVersion,
@@ -99,7 +103,8 @@ object Dependencies {
     // MCP (Model Context Protocol)
     "io.modelcontextprotocol.sdk" % "mcp" % mcpSdkVersion,
     "io.modelcontextprotocol.sdk" % "mcp-core" % mcpSdkVersion,
-    "io.modelcontextprotocol.sdk" % "mcp-spring-webflux" % mcpSdkVersion,
+    "org.springframework.ai" % "spring-ai-starter-mcp-server-webflux" % springAiVersion,
+
     // Database - Slick ORM with PostgreSQL
     "com.typesafe.slick" %% "slick" % slickVersion,
     "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
@@ -116,6 +121,10 @@ object Dependencies {
 
     // Ensure Spring Context is present for classes such as org.springframework.context.i18n.LocaleContext
     "org.springframework" % "spring-context" % springVersion,
+
+    "com.openai" % "openai-java" % openAiVersion,
+
+    "com.google.cloud" % "google-cloud-storage" % googleCloudStorageVersion,
   )
 
   val dependencyOverrides = Seq()

--- a/scala/turnstile/src/main/resources/application.conf
+++ b/scala/turnstile/src/main/resources/application.conf
@@ -76,6 +76,13 @@ turnstile {
     batch-size = 10
     batch-flush-sec = 10
   }
+
+    gcp {
+      storage {
+          file-upload-bucket-name = "portola-file-uploads-staging"
+          blob-upload-bucket-name = "portola-blob-uploads-staging"
+      }
+    }
 }
 
 pekko {

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_client/McpStreamingHttpAsyncClient.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_client/McpStreamingHttpAsyncClient.scala
@@ -176,6 +176,7 @@ class McpStreamingHttpAsyncClient(
       .endpoint(endpoint)
       .connectTimeout(java.time.Duration.ofSeconds(10))
       .resumableStreams(true)
+      .jsonMapper(new PermissiveJsonSchemaMcpJsonMapper())
 
     // Add auth header customizer if token provider is available
     val transportWithAuth = authTokenProvider match {

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_client/PermissiveJsonSchemaMcpJsonMapper.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_client/PermissiveJsonSchemaMcpJsonMapper.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 Sami Malik
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Sami Malik (sami.malik [at] portolanetwork.io)
+ */
+
+package app.dragon.turnstile.mcp_client
+
+import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import io.modelcontextprotocol.json.{McpJsonDefaults, McpJsonMapper, TypeRef}
+
+import java.io.IOException
+
+/**
+ * McpJsonMapper wrapper that normalizes JSON Schema `additionalProperties` before
+ * deserialization.
+ *
+ * The MCP SDK's McpSchema.JsonSchema record types additionalProperties as Boolean, but
+ * JSON Schema (draft-07+) allows it to be either a boolean or a schema object. When a
+ * downstream server returns an object for additionalProperties, Jackson throws a
+ * deserialization error. This wrapper detects that case and removes the field before
+ * passing the JSON to the SDK's default mapper.
+ */
+class PermissiveJsonSchemaMcpJsonMapper extends McpJsonMapper {
+
+  private val delegate = McpJsonDefaults.getMapper()
+  // Uses the Jackson 2 ObjectMapper already on the classpath (via Pekko/Circe)
+  private val preProcessor = new ObjectMapper()
+
+  private def normalizeJson(json: String): String =
+    try {
+      val tree = preProcessor.readTree(json)
+      stripAdditionalPropertiesObjects(tree)
+      preProcessor.writeValueAsString(tree)
+    } catch {
+      case _: Exception => json
+    }
+
+  private def normalizeJson(bytes: Array[Byte]): Array[Byte] =
+    try {
+      val tree = preProcessor.readTree(bytes)
+      stripAdditionalPropertiesObjects(tree)
+      preProcessor.writeValueAsBytes(tree)
+    } catch {
+      case _: Exception => bytes
+    }
+
+  // Recursively removes any `additionalProperties` node that is an object.
+  // JSON Schema allows both boolean and object forms; the SDK only handles boolean.
+  // Removing the field (rather than converting to true/false) is the safest no-op.
+  private def stripAdditionalPropertiesObjects(node: JsonNode): Unit = {
+    node match {
+      case obj: ObjectNode =>
+        Option(obj.get("additionalProperties")) match {
+          case Some(ap) if ap.isObject => obj.remove("additionalProperties")
+          case _ =>
+        }
+        obj.properties().forEach(entry => stripAdditionalPropertiesObjects(entry.getValue))
+      case arr: ArrayNode =>
+        arr.forEach(child => stripAdditionalPropertiesObjects(child))
+      case _ =>
+    }
+  }
+
+  @throws[IOException]
+  override def readValue[T](content: String, tpe: Class[T]): T =
+    delegate.readValue(normalizeJson(content), tpe)
+
+  @throws[IOException]
+  override def readValue[T](content: Array[Byte], tpe: Class[T]): T =
+    delegate.readValue(normalizeJson(content), tpe)
+
+  @throws[IOException]
+  override def readValue[T](content: String, tpe: TypeRef[T]): T =
+    delegate.readValue(normalizeJson(content), tpe)
+
+  @throws[IOException]
+  override def readValue[T](content: Array[Byte], tpe: TypeRef[T]): T =
+    delegate.readValue(normalizeJson(content), tpe)
+
+  override def convertValue[T](fromValue: Object, tpe: Class[T]): T =
+    delegate.convertValue(fromValue, tpe)
+
+  override def convertValue[T](fromValue: Object, tpe: TypeRef[T]): T =
+    delegate.convertValue(fromValue, tpe)
+
+  @throws[IOException]
+  override def writeValueAsString(value: Object): String =
+    delegate.writeValueAsString(value)
+
+  @throws[IOException]
+  override def writeValueAsBytes(value: Object): Array[Byte] =
+    delegate.writeValueAsBytes(value)
+}

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_server/McpStreamingHttpServer.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_server/McpStreamingHttpServer.scala
@@ -19,7 +19,7 @@
 package app.dragon.turnstile.mcp_server
 
 import app.dragon.turnstile.config.ApplicationConfig
-import io.modelcontextprotocol.json.McpJsonMapper
+import io.modelcontextprotocol.json.McpJsonDefaults
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification
 import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider
 import io.modelcontextprotocol.server.{McpAsyncServer, McpServer}
@@ -155,7 +155,7 @@ class McpStreamingHttpServer(
     started = true
     logger.info(s"Creating MCP server for user $userId: $serverName v$serverVersion")
 
-    val jsonMapper = McpJsonMapper.getDefault
+    val jsonMapper = McpJsonDefaults.getMapper()
 
     // Create WebFlux transport provider
     val transportProvider = WebFluxStreamableServerTransportProvider.builder()

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/ToolsService.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/ToolsService.scala
@@ -110,7 +110,7 @@ class ToolsService(
     //Echo("echo2"),
     //StreamingExample,
     //SystemInfo,
-    SearchTools(userId, "default"),
+    //SearchTools(userId, "default"),
     ExecTool(userId, "default"),
     ListMcpServers(userId, "default"),
     ListToolsForMcpServer(userId, "default")

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/ToolsService.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/ToolsService.scala
@@ -109,7 +109,8 @@ class ToolsService(
     //Echo("echo1"),
     //Echo("echo2"),
     //StreamingExample,
-    SystemInfo,
+    //SystemInfo,
+    SearchTools(userId, "default"),
     ExecTool(userId, "default"),
     ListMcpServers(userId, "default"),
     ListToolsForMcpServer(userId, "default")
@@ -167,6 +168,11 @@ class ToolsService(
    * @param mcpServerRow The MCP server row from the database
    * @return A Future containing either an error or a list of namespaced tools
    */
+  private def namespacedToolName(serverName: String, toolName: String): String = {
+    val sanitize = (s: String) => s.replaceAll("[^a-zA-Z0-9_-]", "_")
+    s"${sanitize(serverName)}__${sanitize(toolName)}".take(64)
+  }
+
   private[mcp_tools] def getDownstreamTools(
     mcpServerRow: McpServerRow
   ): Future[Either[McpClientError, List[McpTool]]] = {
@@ -186,7 +192,7 @@ class ToolsService(
           // Convert each tool schema to a NamespacedTool
           val downstreamTools = tools.map { downstreamToolSchema =>
             val turnstileToolSchema = McpSchema.Tool.builder()
-              .name(s"${mcpServerRow.name}.${downstreamToolSchema.name()}")
+              .name(namespacedToolName(mcpServerRow.name, downstreamToolSchema.name()))
               .description(downstreamToolSchema.description())
               .inputSchema(downstreamToolSchema.inputSchema())
               .outputSchema(downstreamToolSchema.outputSchema())

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/impl/ListToolsForMcpServer.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/impl/ListToolsForMcpServer.scala
@@ -22,11 +22,11 @@ import app.dragon.turnstile.db.{DbInterface, DbNotFound}
 import app.dragon.turnstile.mcp_client.McpClientActor
 import app.dragon.turnstile.mcp_tools.{AsyncToolHandler, McpTool, McpUtils}
 import app.dragon.turnstile.utils.ActorLookup
-import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import io.circe.Json
 import io.circe.jackson.jacksonToCirce
 import io.circe.syntax.*
-import io.modelcontextprotocol.json.McpJsonMapper
+import io.modelcontextprotocol.json.McpJsonDefaults
 import io.modelcontextprotocol.spec.McpSchema
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.cluster.sharding.typed.scaladsl.ClusterSharding
@@ -127,9 +127,12 @@ class ListToolsForMcpServer(
   db: Database
 ) extends McpTool {
 
-  // Ask timeout for listing tools from a downstream MCP server.
-  // Kept reasonably low to avoid long-hanging requests while still allowing for slow backends.
   implicit val timeout: Timeout = 60.seconds
+
+  // Jackson 2 ObjectMapper for converting McpSchema.JsonSchema to Circe Json.
+  // McpJsonDefaults.getMapper() wraps Jackson 3 (tools.jackson), which cannot produce
+  // com.fasterxml.jackson.databind.JsonNode (Jackson 2). We bridge via a JSON string.
+  private val jackson2 = new ObjectMapper()
 
   /**
    * Validate a regex pattern by attempting to compile it.
@@ -196,7 +199,7 @@ class ListToolsForMcpServer(
         "name" -> tool.name().asJson,
         "description" -> Option(tool.description()).asJson,
         "inputSchema" -> jacksonToCirce(
-          McpJsonMapper.getDefault.convertValue(tool.inputSchema(), classOf[JsonNode])
+          jackson2.readTree(McpJsonDefaults.getMapper().writeValueAsString(tool.inputSchema()))
         )
       )
     }

--- a/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/impl/ListToolsForMcpServer.scala
+++ b/scala/turnstile/src/main/scala/app/dragon/turnstile/mcp_tools/impl/ListToolsForMcpServer.scala
@@ -198,9 +198,9 @@ class ListToolsForMcpServer(
       Json.obj(
         "name" -> tool.name().asJson,
         "description" -> Option(tool.description()).asJson,
-        "inputSchema" -> jacksonToCirce(
-          jackson2.readTree(McpJsonDefaults.getMapper().writeValueAsString(tool.inputSchema()))
-        )
+        "inputSchema" -> (Try(jackson2.readTree(McpJsonDefaults.getMapper().writeValueAsString(tool.inputSchema()))) match
+          case Success(node) => jacksonToCirce(node)
+          case Failure(e)    => logger.warn(s"Failed to parse inputSchema for ${tool.name()}: ${e.getMessage}"); Json.Null)
       )
     }
 


### PR DESCRIPTION
## Pull request overview

Upgrades Turnstile’s MCP integration to the newer MCP SDK APIs, adjusting JSON mapper usage and tool exposure so the gateway/server can interoperate with updated SDK behavior and downstream schema variants.

**Changes:**
- Bump MCP SDK and related dependencies; swap WebFlux transport dependency to Spring AI starter.
- Update MCP JSON mapper usage (`McpJsonDefaults`) and add a permissive JSON-schema mapper to tolerate downstream `additionalProperties` schema objects.
- Change downstream tool namespacing format and add new Turnstile config entries.

### Reviewed changes

Copilot reviewed 7 out of 7 changed files in this pull request and generated 6 comments.




